### PR TITLE
Refactor `progress` function to add type hints and improve flexibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,85 @@
+TinyProgress
+============
+
+.. image:: https://img.shields.io/pypi/v/tinyprogress
+   :alt: PyPI - Version
+.. image:: https://img.shields.io/pypi/dm/tinyprogress
+   :alt: PyPI - Downloads
+.. image:: https://img.shields.io/pepy/dt/tinyprogress
+   :alt: Pepy Total Downloads
+
+
+.. image:: https://img.shields.io/github/license/croketillo/tinyprogress
+   :alt: GitHub License
+.. image:: https://img.shields.io/github/size/croketillo/tinyprogress/tinyprogress/tinyprogress.py
+   :alt: GitHub file size in bytes
+
+
+
+**TinyProgress** is a minimal and lightweight progress bar module for
+Python. It provides an easy way to track progress in loops and iterables
+without requiring external dependencies.
+
+🚀 Features
+----------
+
+-  ✅ Simple and lightweight (no external dependencies)
+-  ✅ Customizable progress bar length and characters
+-  ✅ Supports named tasks
+-  ✅ Works with any iterable
+
+📦 Installation
+--------------
+
+Since TinyProgress is a single-file module, you can simply copy
+``tinyprogress.py`` into your project.
+
+Alternatively, install it via pip (once published to PyPI):
+
+.. code:: sh
+
+   pip install tinyprogress
+
+🛠 Usage
+-------
+
+Basic Progress Bar
+~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   from tinyprogress import progress
+   import time
+
+   for i in progress(range(100)):
+       time.sleep(0.05)  # Simulating work
+
+Custom Progress Bar Length
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   for i in progress(range(100), bar_length=50):
+       time.sleep(0.05)
+
+Named Task Progress Bar
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   for i in progress(range(100), task_name="Downloading"):
+       time.sleep(0.05)
+
+Using Custom Characters
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: python
+
+   for i in progress(range(100), fill_char='#', empty_char='-'):
+       time.sleep(0.05)
+
+📜 License
+---------
+
+GNU General Public License v3, see LICENSE file.
+

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -13,7 +13,7 @@ import sys
 T_co = TypeVar('T_co', covariant=True)
 
 
-class SizedIterable(Iterable[T_co], Sized, Protocol[T_co]): ...
+class SizedIterable(Iterable[T_co], Sized, Protocol): ...
 
 
 @overload

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -10,6 +10,7 @@ from typing import (
 )
 import sys
 
+T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
 
 
@@ -18,34 +19,34 @@ class SizedIterable(Iterable[T_co], Sized, Protocol): ...
 
 @overload
 def progress(
-    iterable: Iterable[T_co],
+    iterable: Iterable[T],
     total: int,
     bar_length: int = 40,
     fill_char: str = '█',
     empty_char: str = ' ',
     task_name: Optional[str] = None
-) -> Generator[T_co, None, None]: ...
+) -> Generator[T, None, None]: ...
 
 
 @overload
 def progress(
-    iterable: SizedIterable[T_co],
+    iterable: SizedIterable[T],
     total: Optional[int] = None,
     bar_length: int = 40,
     fill_char: str = '█',
     empty_char: str = ' ',
     task_name: Optional[str] = None
-) -> Generator[T_co, None, None]: ...
+) -> Generator[T, None, None]: ...
 
 
 def progress(
-    iterable: Union[Iterable[T_co], SizedIterable[T_co]],
+    iterable: Union[Iterable[T], SizedIterable[T]],
     total: Optional[int] = None,
     bar_length: int = 40,
     fill_char: str= '█',
     empty_char: str = ' ',
     task_name: Optional[str] = None
-) -> Generator[T_co, None, None]:
+) -> Generator[T, None, None]:
     """
     A lightweight progress bar for iterables.
 

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -1,15 +1,17 @@
-from typing import Optional, Iterable, Any
+from typing import Generator, Optional, Iterable, TypeVar
 import sys
+
+T = TypeVar('T')
 
 
 def progress(
-    iterable: Iterable[Any],
+    iterable: Iterable[T],
     total: Optional[int] = None,
     bar_length: int = 40,
     fill_char: str= '█',
     empty_char: str = ' ',
     task_name: Optional[str] = None
-) -> None:
+) -> Generator[T, None, None]:
     """
     A lightweight progress bar for iterables.
 
@@ -30,10 +32,10 @@ def progress(
     """
     if total is None:
         try:
-            total = len(iterable)
+            total = len(iterable)  # type: ignore
         except TypeError:
             raise ValueError("Total iterations must be specified for non-sized iterables.")
-    
+
     for i, item in enumerate(iterable, 1):
         progress = i / total
         filled_length = int(bar_length * progress)

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -1,11 +1,21 @@
-from typing import Generator, Optional, Iterable, TypeVar
+from typing import (
+    Generator,
+    Optional,
+    Iterable,
+    TypeVar,
+    Sized,
+    Protocol
+)
 import sys
 
-T = TypeVar('T')
+T = TypeVar('T', covariant=True)
+
+
+class SizedIterable(Iterable[T], Sized, Protocol): ...
 
 
 def progress(
-    iterable: Iterable[T],
+    iterable: SizedIterable[T],
     total: Optional[int] = None,
     bar_length: int = 40,
     fill_char: str= '█',
@@ -32,7 +42,7 @@ def progress(
     """
     if total is None:
         try:
-            total = len(iterable)  # type: ignore
+            total = len(iterable)
         except TypeError:
             raise ValueError("Total iterations must be specified for non-sized iterables.")
 

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -1,16 +1,32 @@
+from typing import Optional, Iterable, Any
 import sys
 
 
-def progress(iterable, total=None, bar_length=40, fill_char='█', empty_char=' ', task_name=None):
+def progress(
+    iterable: Iterable[Any],
+    total: Optional[int] = None,
+    bar_length: int = 40,
+    fill_char: str= '█',
+    empty_char: str = ' ',
+    task_name: Optional[str] = None
+) -> None:
     """
     A lightweight progress bar for iterables.
-    
+
     :param iterable: The iterable to wrap.
+    :type iterable: Iterable[Any]
     :param total: Total number of iterations (optional, inferred from iterable if None).
+    :type total: Optional[int]
     :param bar_length: Length of the progress bar in characters.
+    :type bar_length: int
     :param fill_char: Character used to fill the progress bar.
+    :type fill_char: str
     :param empty_char: Character used to represent remaining progress.
-    :param task_name: Name of the task being executed (optional, defaults to None).
+    :type empty_char: str
+    :param task_name: Name of the task being executed (optional).
+    :type task_name: Optional[str]
+    :return: None
+    :rtype: None
     """
     if total is None:
         try:


### PR DESCRIPTION
This PR adds type hints to the progress function, making it more flexible and type-safe. Changes include:
	•	Switched to using `TypeVar` for the iterable and updated the return type to `Generator[T, None, None]`.
	•	Made total optional and used `Iterable[T]` for the iterable.
	•	Cleaned up the code to make it a bit clearer and more readable.
