### PR TITLE
Allow more customization of the progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ for i in progress(range(100), task_name="Downloading"):
 for i in progress(range(100), fill_char='#', empty_char='-'):
     time.sleep(0.05)
 ```
+### Using Custom Colors
+```python
+def bar_color(progress: float) -> str:
+    if progress < 0.7:  # 70%
+        return '\033[31m'
+    return '\033[32m'
+
+def text_color(progress: float) -> str:
+    return '\033[35m'
+
+
+for i in progress(
+    range(100),
+    task_name='Colored bar',
+    fill_char='—',
+    start_char=' ',
+    end_char=' ',
+    bar_color=bar_color,
+    text_color=text_color
+):
+    time.sleep(0.05)
+```
 
 ## 📜 License
 GNU General Public License v3, see LICENSE file.

--- a/prueba.py
+++ b/prueba.py
@@ -26,5 +26,26 @@ for i in progress(range(100), fill_char='/', empty_char='-'):
 
 for i in progress(range(100), fill_char='—', start_char='', end_char=''):
     time.sleep(0.05)
+    
+print('\nCUSTOM COLORS')
+def bar_color(progress: float) -> str:
+    if progress < 0.7:
+        return '\033[31m'
+    return '\033[32m'
+
+def text_color(progress: float) -> str:
+    return '\033[35m'
+
+
+for i in progress(
+    range(100),
+    task_name='Colored bar',
+    fill_char='—',
+    start_char=' ',
+    end_char=' ',
+    bar_color=bar_color,
+    text_color=text_color
+):
+    time.sleep(0.05)
 
 print("\n\n")

--- a/prueba.py
+++ b/prueba.py
@@ -24,4 +24,7 @@ for i in progress(range(100), fill_char='/', empty_char='-'):
     time.sleep(0.05)
 
 
+for i in progress(range(100), fill_char='—', start_char='', end_char=''):
+    time.sleep(0.05)
+
 print("\n\n")

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -79,6 +79,10 @@ def progress(
     :param start_char: The start character (default: [)
     :type end_char: str
     :param end_char: The end character (default: ])
+    :type text_color: Callable[[float], str]
+    :param text_color: A callable that takes in a value from 0 to 1 (0-100%) and returns a string with the color of the text
+    :type bar_color: Callable[[float], str]
+    :param bar_color: Similar to ``text_color`` but for the color of the bar
     :return: None
     :rtype: None
     """

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -15,6 +15,7 @@ import sys
 
 ColorCallable = Callable[[float], str]
 reset_color = lambda _: '\033[0m'  # noqa: E731
+default_color = lambda _: ''
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
@@ -85,8 +86,10 @@ def progress(
     empty_char = options.get('empty_char', ' ')
     start_char = options.get('start_char', '[')
     end_char = options.get('end_char', ']')
-    text_color = options.get('text_color', reset_color)
-    bar_color = options.get('bar_color', reset_color)
+    text_color = options.get('text_color', default_color)
+    bar_color = options.get('bar_color', default_color)
+    if text_color is default_color:
+        reset_color = default_color
 
     if total is None:
         if isinstance(iterable, Sized):

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -19,7 +19,7 @@ T_co = TypeVar('T_co', covariant=True)
 class SizedIterable(Iterable[T_co], Sized, Protocol): ...
 
 
-class Options(TypedDict):
+class Options(TypedDict, total=False):
     start_char: str
     end_char: str
     fill_char: str

--- a/tinyprogress/tinyprogress.py
+++ b/tinyprogress/tinyprogress.py
@@ -15,7 +15,7 @@ import sys
 
 ColorCallable = Callable[[float], str]
 reset_color = lambda _: '\033[0m'  # noqa: E731
-default_color = lambda _: ''
+default_color = lambda _: ''  # noqa: E731
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
@@ -89,7 +89,9 @@ def progress(
     text_color = options.get('text_color', default_color)
     bar_color = options.get('bar_color', default_color)
     if text_color is default_color:
-        reset_color = default_color
+        _reset = default_color
+    else:
+        _reset = reset_color
 
     if total is None:
         if isinstance(iterable, Sized):
@@ -103,9 +105,9 @@ def progress(
         bar = fill_char * filled_length + empty_char * (bar_length - filled_length)
         task_display = f"{task_name} " if task_name else ""
         sys.stdout.write((
-            f'\r{text_color(progress)}{task_display}{reset_color(progress)}'
-            f'{bar_color(progress)}{start_char}{bar}{end_char}{reset_color(progress)}'
-            f'{text_color(progress)}{int(progress * 100)}%  {i}/{total}{reset_color(progress)}'
+            f'\r{text_color(progress)}{task_display}{_reset(progress)}'
+            f'{bar_color(progress)}{start_char}{bar}{end_char}{_reset(progress)}'
+            f'{text_color(progress)}{int(progress * 100)}%  {i}/{total}{_reset(progress)}'
         ))
         sys.stdout.flush()
         yield item


### PR DESCRIPTION
This PR adds the ability to modify the start/end characters in the progress bar, I've also updated the `prueba.py` file to add a simple example (this file should probably be renamed to use an English name rather than Spanish). Also added the ability to change colors (of the bar itself and the text) based on the percentage of the progress bar.